### PR TITLE
Fix VM count in performance check

### DIFF
--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -93,7 +93,7 @@ class VMwareHealthCheck:
         perf = {
             'cpu_usage': stats.overallCpuUsage,
             'memory_usage': stats.overallMemoryUsage,
-            'num_vms': summary.runtime.numVms
+            'num_vms': len(getattr(host, 'vm', []))
         }
         # Additional metrics can be gathered from host.configManager or perfManager
         return perf


### PR DESCRIPTION
## Summary
- handle VM counting correctly in `performance_check`

## Testing
- `python -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_6843ea91c958832c90fa6df98004a4fa