### PR TITLE
Switch to lockdownMode in security check

### DIFF
--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -66,7 +66,9 @@ class VMwareHealthCheck:
         security = {}
         security['name'] = summary.config.name
         security['version'] = summary.config.product.fullName
-        security['lockdown_mode'] = config.adminDisabled
+        # "lockdownMode" reflects whether the host restricts direct remote
+        # management access (normal, lockdown or strict modes)
+        security['lockdown_mode'] = config.lockdownMode
         security['services'] = {
             'ssh': any(s.key == 'TSM-SSH' and s.running for s in host.configManager.serviceSystem.serviceInfo.service),
             'esxi_shell': any(s.key == 'TSM' and s.running for s in host.configManager.serviceSystem.serviceInfo.service)


### PR DESCRIPTION
## Summary
- reference `config.lockdownMode` instead of the deprecated `adminDisabled`
- clarify what `lockdownMode` means in a code comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843f25329d4832c946a855a333a56e0