### PR TITLE
Convert memory_total to GB in healthcheck

### DIFF
--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -103,7 +103,8 @@ class VMwareHealthCheck:
         bp = {}
         hardware = host.hardware
         bp['cpu_model'] = hardware.cpuPkg[0].description if hardware.cpuPkg else 'n/a'
-        bp['memory_total'] = hardware.memorySize
+        # Convert memory size from bytes to gigabytes for easier readability
+        bp['memory_total_gb'] = hardware.memorySize / (1024 ** 3)
         bp['datastores'] = [ds.info.name for ds in host.datastore]
         bp['network'] = [nw.name for nw in host.network]
         return bp


### PR DESCRIPTION
## Summary
- convert `hardware.memorySize` to gigabytes in the best practice check
- report memory in GB in console output and HTML

## Testing
- `python -m py_compile vmware_healthcheck.py`


------
https://chatgpt.com/codex/tasks/task_b_6843f8030c9c832cb8842c9d0aeb5776