### PR TITLE
Add VM metrics with CPU Ready ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
    python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> --output reporte.html
    ```
 
-El script mostrará por pantalla un resumen de la información recopilada para cada host detectado.
+El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.
+El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.


### PR DESCRIPTION
## Summary
- gather VM performance stats including CPU ready, disk, network
- generate HTML report with a Top 10 VM CPU Ready table and per-VM metrics
- print VM metrics on the console
- document new report details in README

## Testing
- `python -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_6843fa061bc4832c9956d49fcfffbae1