### PR TITLE
Improve VM metrics aggregation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ El script mostrará por pantalla un resumen de la información recopilada para c
 El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.
+
+### Unidades de las métricas
+
+- `cpu_ready_ms`: tiempo medio de CPU Ready expresado en milisegundos.
+- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100 %).
+- `disk_reads` y `disk_writes`: número medio de operaciones por intervalo.
+- `net_rx_kbps` y `net_tx_kbps`: velocidad media de recepción y envío en KB/s.

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -169,14 +169,33 @@ class VMwareHealthCheck:
         )
 
         stats = pm.QueryStats(querySpec=[spec])
-        metrics = {v: 0 for v in metric_names.values()}
+        # Collect samples by metric field
+        samples = {v: [] for v in metric_names.values()}
         if stats:
             vals = stats[0].value
             for val in vals:
                 for name, field in metric_names.items():
-                    if counters.get(name) == val.id.counterId:
-                        if val.value:
-                            metrics[field] = sum(val.value) / len(val.value)
+                    if counters.get(name) == val.id.counterId and val.value:
+                        if name.endswith('summation') or name.startswith('disk') or name.startswith('net.'):
+                            # Sum across instances (e.g. multiple disks or NICs)
+                            if len(samples[field]) < len(val.value):
+                                samples[field] += [0] * (len(val.value) - len(samples[field]))
+                            for i, v in enumerate(val.value):
+                                samples[field][i] += v
+                        else:
+                            # Average type metrics - just store all values
+                            samples[field].extend(val.value)
+
+        metrics = {}
+        for name, field in metric_names.items():
+            values = samples.get(field, [])
+            if values:
+                metrics[field] = sum(values) / len(values)
+            else:
+                metrics[field] = 0
+
+        metrics['cpu_usage_pct'] /= 100.0
+        metrics['mem_usage_pct'] /= 100.0
         return metrics
 
     def best_practice_check(self, host):
@@ -273,13 +292,13 @@ class VMwareHealthCheck:
             if h.get('vms'):
                 html.append("<h3>VM Metrics</h3>")
                 html.append("<table>")
-                html.append("<tr><th>Name</th><th>CPU Ready (ms)</th><th>CPU Usage (%)</th><th>Memory Usage (%)</th><th>Disk Reads</th><th>Disk Writes</th><th>Net RX</th><th>Net TX</th></tr>")
+                html.append("<tr><th>Name</th><th>CPU Ready (ms)</th><th>CPU Usage (%)</th><th>Memory Usage (%)</th><th>Disk Reads (ops)</th><th>Disk Writes (ops)</th><th>Net RX (KB/s)</th><th>Net TX (KB/s)</th></tr>")
                 for vm in h['vms']:
                     m = vm['metrics']
                     html.append(
                         f"<tr><td>{vm['name']}</td><td>{m.get('cpu_ready_ms', 0)}</td>"
-                        f"<td>{m.get('cpu_usage_pct', 0)}</td>"
-                        f"<td>{m.get('mem_usage_pct', 0)}</td>"
+                        f"<td>{round(m.get('cpu_usage_pct', 0) * 100, 2)}</td>"
+                        f"<td>{round(m.get('mem_usage_pct', 0) * 100, 2)}</td>"
                         f"<td>{m.get('disk_reads', 0)}</td>"
                         f"<td>{m.get('disk_writes', 0)}</td>"
                         f"<td>{m.get('net_rx_kbps', 0)}</td>"
@@ -335,6 +354,8 @@ def main():
             for vm in vm_info:
                 print('  VM: {}'.format(vm['name']))
                 for mk, mv in vm['metrics'].items():
+                    if mk in ('cpu_usage_pct', 'mem_usage_pct'):
+                        mv = round(mv * 100, 2)
                     print('    {}: {}'.format(mk, mv))
             print()
 


### PR DESCRIPTION
## Summary
- aggregate samples across VM metrics and average across instances
- scale CPU and memory usage to real percentages
- update printed and HTML output with new values
- document metric units

## Testing
- `python -m py_compile vmware_healthcheck.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843fc8edd60832c926059267cc37f68