### PR TITLE
Add Jinja2 templating for HTML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ El script mostrará por pantalla un resumen de la información recopilada para c
 El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.
+
+## Pruebas
+
+Para ejecutar las pruebas unitarias incluidas, utilice el módulo `unittest` de Python:
+
+```bash
+python -m unittest
+```

--- a/README.md
+++ b/README.md
@@ -13,23 +13,22 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
    ```bash
    pip install -r requirements.txt
    ```
-
 2. Ejecute el script proporcionando los datos de conexión. Puede especificar opcionalmente un archivo de salida HTML:
    ```bash
    python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> --output reporte.html
    ```
-
 3. El informe se genera a partir de la plantilla `template.html`. Puede personalizarla para cambiar la apariencia del reporte.
 
 El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.
 El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM. Además, se recopila información de datastores, interfaces de red y firmware de cada host.
+Si se desean añadir contadores de rendimiento adicionales por VM basta con proporcionar un diccionario `metric_names` al método `vm_performance_check`.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.
 
 ### Unidades de las métricas
 
 - `cpu_ready_ms`: tiempo medio de CPU Ready expresado en milisegundos.
-- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100 %).
+- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100 %).
 - `disk_reads` y `disk_writes`: número medio de operaciones por intervalo.
 - `net_rx_kbps` y `net_tx_kbps`: velocidad media de recepción y envío en KB/s.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Si se desean añadir contadores de rendimiento adicionales por VM basta con prop
 ### Unidades de las métricas
 
 - `cpu_ready_ms`: tiempo medio de CPU Ready expresado en milisegundos.
-- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100 %).
+- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100%).
 - `disk_reads` y `disk_writes`: número medio de operaciones por intervalo.
 - `net_rx_kbps` y `net_tx_kbps`: velocidad media de recepción y envío en KB/s.
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
 3. El informe se genera a partir de la plantilla `template.html`. Puede personalizarla para cambiar la apariencia del reporte.
 
 El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.
-El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.
+El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM. Además, se recopila información de datastores, interfaces de red y firmware de cada host.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.
+
+### Unidades de las métricas
+
+- `cpu_ready_ms`: tiempo medio de CPU Ready expresado en milisegundos.
+- `cpu_usage_pct` y `mem_usage_pct`: porcentajes reales (1.0 corresponde al 100 %).
+- `disk_reads` y `disk_writes`: número medio de operaciones por intervalo.
+- `net_rx_kbps` y `net_tx_kbps`: velocidad media de recepción y envío en KB/s.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
 ## Requisitos
 
 - Python 3.8+
-- Dependencias indicadas en `requirements.txt` (`pyvmomi`, `matplotlib`)
+- Dependencias indicadas en `requirements.txt` (`pyvmomi`, `matplotlib`, `jinja2`)
 
 ## Instalación
 
@@ -18,6 +18,8 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
    ```bash
    python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> --output reporte.html
    ```
+
+3. El informe se genera a partir de la plantilla `template.html`. Puede personalizarla para cambiar la apariencia del reporte.
 
 El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.
 El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyvmomi
 matplotlib
+jinja2

--- a/template.html
+++ b/template.html
@@ -1,0 +1,62 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>VMware Health Check</title>
+<style>
+body{font-family:Arial;}
+ table{border-collapse:collapse;}
+ th,td{border:1px solid #ccc;padding:4px;}
+ h1,h2{color:#2c3e50;}
+</style>
+</head>
+<body>
+<h1>VMware Health Check Report</h1>
+<img src="data:image/png;base64,{{ chart }}" alt="Resource Usage Chart"/>
+<h2>Top 10 VMs by CPU Ready</h2>
+<table>
+<tr><th>VM</th><th>CPU Ready (ms)</th></tr>
+{% for v in vm_data | sort(attribute='metrics.cpu_ready_ms', reverse=True)[:10] %}
+<tr><td>{{ v.name }}</td><td>{{ v.metrics.cpu_ready_ms }}</td></tr>
+{% endfor %}
+</table>
+{% for h in hosts_data %}
+<h2>Host: {{ h.name }}</h2>
+<h3>Security</h3>
+<table>
+{% for k, v in h.security.items() %}
+<tr><th>{{ k }}</th><td>{{ v }}</td></tr>
+{% endfor %}
+</table>
+<h3>Performance</h3>
+<table>
+{% for k, v in h.performance.items() %}
+<tr><th>{{ k }}</th><td>{{ v }}</td></tr>
+{% endfor %}
+</table>
+<h3>Best Practices</h3>
+<table>
+{% for k, v in h.best_practice.items() %}
+<tr><th>{{ k }}</th><td>{{ v }}</td></tr>
+{% endfor %}
+</table>
+{% if h.vms %}
+<h3>VM Metrics</h3>
+<table>
+<tr><th>Name</th><th>CPU Ready (ms)</th><th>CPU Usage (%)</th><th>Memory Usage (%)</th><th>Disk Reads</th><th>Disk Writes</th><th>Net RX</th><th>Net TX</th></tr>
+{% for vm in h.vms %}
+<tr>
+<td>{{ vm.name }}</td>
+<td>{{ vm.metrics.cpu_ready_ms }}</td>
+<td>{{ vm.metrics.cpu_usage_pct }}</td>
+<td>{{ vm.metrics.mem_usage_pct }}</td>
+<td>{{ vm.metrics.disk_reads }}</td>
+<td>{{ vm.metrics.disk_writes }}</td>
+<td>{{ vm.metrics.net_rx_kbps }}</td>
+<td>{{ vm.metrics.net_tx_kbps }}</td>
+</tr>
+{% endfor %}
+</table>
+{% endif %}
+{% endfor %}
+</body>
+</html>

--- a/tests/test_vmware_healthcheck.py
+++ b/tests/test_vmware_healthcheck.py
@@ -1,0 +1,136 @@
+import unittest
+from unittest import mock
+from types import SimpleNamespace
+import os
+import tempfile
+import sys
+
+# Provide dummy pyVim and pyVmomi modules so the tests do not require the real VMware libraries to be installed.
+vim_fake = mock.MagicMock()
+pyvmomi_fake = mock.MagicMock(vim=vim_fake)
+sys.modules.setdefault('pyVmomi', pyvmomi_fake)
+sys.modules.setdefault('pyVmomi.vim', vim_fake)
+connect_fake = mock.MagicMock(SmartConnect=mock.MagicMock(), Disconnect=mock.MagicMock())
+pyvim_fake = mock.MagicMock(connect=connect_fake)
+sys.modules.setdefault('pyVim', pyvim_fake)
+sys.modules.setdefault('pyVim.connect', connect_fake)
+
+# Stub matplotlib modules used by the script so tests don't require the actual library.
+matplotlib_fake = mock.MagicMock()
+pyplot_fake = mock.MagicMock()
+matplotlib_fake.pyplot = pyplot_fake
+sys.modules.setdefault('matplotlib', matplotlib_fake)
+sys.modules.setdefault('matplotlib.pyplot', pyplot_fake)
+
+# Stub jinja2 so it is not required during tests
+class FakeTemplate:
+    def render(self, *args, **kwargs):
+        return "VMware Health Check Report"
+
+class FakeEnvironment:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_template(self, name):
+        return FakeTemplate()
+
+jinja2_fake = mock.MagicMock(Environment=FakeEnvironment, FileSystemLoader=mock.MagicMock())
+sys.modules.setdefault('jinja2', jinja2_fake)
+
+from vmware_healthcheck import VMwareHealthCheck
+
+
+class VMwareHealthCheckTests(unittest.TestCase):
+    def _fake_host(self):
+        host = SimpleNamespace()
+        host.name = 'esxi1'
+        host.summary = SimpleNamespace(
+            config=SimpleNamespace(
+                name='esxi1',
+                product=SimpleNamespace(fullName='ESXi 7')
+            ),
+            quickStats=SimpleNamespace(
+                overallCpuUsage=1000,
+                overallMemoryUsage=2048
+            )
+        )
+        host.config = SimpleNamespace(
+            lockdownMode='strict'
+        )
+        host.configManager = SimpleNamespace(
+            serviceSystem=SimpleNamespace(
+                serviceInfo=SimpleNamespace(
+                    service=[
+                        SimpleNamespace(key='TSM-SSH', running=True),
+                        SimpleNamespace(key='TSM', running=False)
+                    ]
+                )
+            ),
+            firewallSystem=SimpleNamespace(
+                firewallInfo=SimpleNamespace(
+                    ruleset=[SimpleNamespace(key='ssh'), SimpleNamespace(key='http')]
+                )
+            )
+        )
+        host.config.dateTimeInfo = SimpleNamespace(
+            ntpConfig=SimpleNamespace(server=['0.pool.ntp.org', '1.pool.ntp.org'])
+        )
+        host.hardware = SimpleNamespace(
+            cpuPkg=[SimpleNamespace(description='Intel Xeon')],
+            memorySize=16 * 1024 ** 3
+        )
+        host.datastore = [SimpleNamespace(info=SimpleNamespace(name='ds1'))]
+        host.network = [SimpleNamespace(name='nw1')]
+        host.vm = [SimpleNamespace(name='vm1'), SimpleNamespace(name='vm2')]
+        return host
+
+    def test_security_check(self):
+        checker = VMwareHealthCheck('h', 'u', 'p')
+        host = self._fake_host()
+        result = checker.security_check(host)
+        self.assertEqual(result['lockdown_mode'], 'strict')
+        self.assertIn('ssh', result['services'])
+        self.assertTrue(result['services']['ssh'])
+        self.assertEqual(result['ntp_servers'], ['0.pool.ntp.org', '1.pool.ntp.org'])
+        self.assertEqual(result['firewall_exceptions'], ['ssh', 'http'])
+
+    def test_performance_check(self):
+        checker = VMwareHealthCheck('h', 'u', 'p')
+        host = self._fake_host()
+        result = checker.performance_check(host)
+        self.assertEqual(result['cpu_usage'], 1000)
+        self.assertEqual(result['memory_usage'], 2048)
+        self.assertEqual(result['num_vms'], 2)
+
+    def test_best_practice_check(self):
+        checker = VMwareHealthCheck('h', 'u', 'p')
+        host = self._fake_host()
+        result = checker.best_practice_check(host)
+        self.assertEqual(result['cpu_model'], 'Intel Xeon')
+        self.assertEqual(result['memory_total_gb'], 16)
+        self.assertEqual(result['datastores'], ['ds1'])
+        self.assertEqual(result['network'], ['nw1'])
+
+    def test_generate_report_creates_file(self):
+        checker = VMwareHealthCheck('h', 'u', 'p')
+        hosts_data = [
+            {
+                'name': 'host1',
+                'security': {'lockdown': 'on'},
+                'performance': {'cpu_usage': 10, 'memory_usage': 20},
+                'best_practice': {'cpu_model': 'model'},
+                'vms': []
+            }
+        ]
+        vm_data = []
+        with tempfile.TemporaryDirectory() as td:
+            output = os.path.join(td, 'report.html')
+            with mock.patch.object(checker, '_create_chart', return_value='img'):
+                checker.generate_report(hosts_data, vm_data, output)
+            self.assertTrue(os.path.exists(output))
+            with open(output, 'r', encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('VMware Health Check Report', content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -232,6 +232,8 @@ class VMwareHealthCheck:
         ----------
         hosts_data : list of dict
             Información de los hosts analizados.
+        vm_data : list of dict
+            Métricas agregadas de las máquinas virtuales.
         output_file : str
             Ruta del archivo HTML de salida.
         """


### PR DESCRIPTION
## Summary
- include `jinja2` in requirements
- use `template.html` and Jinja2 to render reports
- add HTML template
- document template usage in README

## Testing
- `python -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_6843fd27c184832cad051686ad17dc48