### PR TITLE
Extend host checks and html output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
    ```
 
 El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.
-El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM.
+El informe HTML incluye ahora un ranking con las 10 máquinas virtuales con mayor **CPU Ready** y tablas con métricas detalladas de CPU, memoria, disco y red por VM. Además, se recopila información de datastores, interfaces de red y firmware de cada host.
+
+Si se desean añadir contadores de rendimiento adicionales por VM basta con proporcionar un diccionario `metric_names` al método `vm_performance_check`.
 
 **Nota**: este script es un punto de partida y no sustituye a una auditoría completa. Puede ampliarse para cubrir todas las comprobaciones de seguridad, rendimiento y mejores prácticas descritas en la solicitud original.


### PR DESCRIPTION
## Summary
- gather datastore, network and firmware info in best practice and performance checks
- allow additional VM counters via optional `metric_names`
- display new host information in HTML report
- document new counters in README

## Testing
- `python3 -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_6843fd2ced34832c8307c2d622983a3d