### PR TITLE
Fix datastore handling in report generation

### DIFF
--- a/tests/test_vmware_healthcheck.py
+++ b/tests/test_vmware_healthcheck.py
@@ -118,5 +118,26 @@ class VMwareHealthCheckTests(unittest.TestCase):
                 content = f.read()
             self.assertIn('VMware Health Check Report', content)
 
+    def test_report_handles_string_datastores(self):
+        checker = VMwareHealthCheck('h', 'u', 'p')
+        hosts_data = [{
+            'name': 'host1',
+            'security': {},
+            'performance': {
+                'cpu_usage': 10,
+                'memory_usage': 20,
+                'datastores': [{'name': 'ds1', 'capacity_gb': 1, 'free_gb': 0.5}]
+            },
+            'best_practice': {
+                'cpu_model': 'model',
+                'memory_total_gb': 16,
+                'datastores': ['ds1']
+            },
+            'vms': []
+        }]
+        with mock.patch.object(checker, '_create_chart', return_value='img'):
+            html = checker._generate_report_default(hosts_data, [], 'img')
+        self.assertIn('ds1', html)
+
 if __name__ == '__main__':
     unittest.main()

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -349,7 +349,15 @@ class VMwareHealthCheck:
                 html.append("<h4>Datastores</h4>")
                 html.append("<table><tr><th>Name</th><th>Capacity (GB)</th><th>Free (GB)</th></tr>")
                 for ds in h['performance']['datastores']:
-                    html.append(f"<tr><td>{ds['name']}</td><td>{ds['capacity_gb']:.1f}</td><td>{ds['free_gb']:.1f}</td></tr>")
+                    if isinstance(ds, dict):
+                        name = ds.get('name', 'n/a')
+                        cap = f"{ds.get('capacity_gb', 0):.1f}"
+                        free = f"{ds.get('free_gb', 0):.1f}"
+                    else:
+                        name = str(ds)
+                        cap = 'n/a'
+                        free = 'n/a'
+                    html.append(f"<tr><td>{name}</td><td>{cap}</td><td>{free}</td></tr>")
                 html.append("</table>")
 
             if h['performance'].get('network'):
@@ -367,7 +375,15 @@ class VMwareHealthCheck:
             if h['best_practice'].get('datastores'):
                 html.append("<h4>Datastores</h4><table><tr><th>Name</th><th>Capacity (GB)</th><th>Free (GB)</th></tr>")
                 for ds in h['best_practice']['datastores']:
-                    html.append(f"<tr><td>{ds['name']}</td><td>{ds['capacity_gb']:.1f}</td><td>{ds['free_gb']:.1f}</td></tr>")
+                    if isinstance(ds, dict):
+                        name = ds.get('name', 'n/a')
+                        cap = f"{ds.get('capacity_gb', 0):.1f}"
+                        free = f"{ds.get('free_gb', 0):.1f}"
+                    else:
+                        name = str(ds)
+                        cap = 'n/a'
+                        free = 'n/a'
+                    html.append(f"<tr><td>{name}</td><td>{cap}</td><td>{free}</td></tr>")
                 html.append("</table>")
 
             if h['best_practice'].get('network'):


### PR DESCRIPTION
## Summary
- handle datastore entries that are simple strings in `_generate_report_default`
- add regression test covering string datastores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684477594afc832ca193e29c48b6e16d