### PR TITLE
Fix timezone bug in host runtime calculation

### DIFF
--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -263,7 +263,12 @@ class VMwareHealthCheck:
         runtime = getattr(host, 'runtime', None)
         boot = getattr(runtime, 'bootTime', None)
         if boot:
-            uptime = (datetime.datetime.utcnow() - boot).total_seconds()
+            # Ensure both datetimes are either aware or naive before subtraction
+            if boot.tzinfo is not None:
+                now = datetime.datetime.now(tz=boot.tzinfo)
+            else:
+                now = datetime.datetime.utcnow()
+            uptime = (now - boot).total_seconds()
         else:
             uptime = 0
         return {


### PR DESCRIPTION
## Summary
- handle timezone-aware boot times in `host_runtime_info`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684489b3a660832c8d60975160a5525a