### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ Este repositorio incluye una herramienta sencilla escrita en Python que se conec
 
 ## Instalación
 
-1. Instale las dependencias:
+1. Instale las dependencias ejecutando el script `setup.sh` o, si lo prefiere,
+   instálelas manualmente:
    ```bash
+   ./setup.sh  # instala automáticamente
+   # o bien
    pip install -r requirements.txt
+   ```
+   Para comprobar que Jinja2 se instaló correctamente puede ejecutar:
+   ```bash
+   python -c "import jinja2"
    ```
 
 2. Ejecute el script proporcionando los datos de conexión. Puede especificar opcionalmente un archivo de salida HTML:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Install project dependencies
+set -e
+
+if [ ! -f requirements.txt ]; then
+  echo "requirements.txt not found" >&2
+  exit 1
+fi
+
+python3 -m pip install -r requirements.txt
+


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper script to install required packages
- document running `setup.sh` in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68448f574204832cb2599a7c8056b30d