### PR TITLE
Fix variable names in advanced report template

### DIFF
--- a/template_a.html
+++ b/template_a.html
@@ -365,7 +365,7 @@
             </thead>
             <tbody>
               {% for vm in top_iops %}
-              <tr><td>{{ vm.name }}</td><td>{{ vm.iops }}</td></tr>
+              <tr><td>{{ vm.name }}</td><td>{{ vm.metrics.iops }}</td></tr>
               {% endfor %}
             </tbody>
           </table>
@@ -384,7 +384,7 @@
             </thead>
             <tbody>
               {% for sw in top_network %}
-              <tr><td>{{ sw.name }}</td><td>{{ sw.usage }}</td></tr>
+              <tr><td>{{ sw.name }}</td><td>{{ sw.metrics.net_throughput_kbps }}</td></tr>
               {% endfor %}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- fix metrics references in `template_a.html` so Jinja variables resolve properly

## Testing
- `python -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_68449ba459f8832c87d1424d36f51e51