### PR TITLE
Implement additional VMware health indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,15 @@ Adicionalmente, la versión actual realiza comprobaciones básicas de:
 - Inconsistencias de carpetas o VMs duplicadas.
 - Búsqueda de VMDK "zombies" no asociados a una VM.
 - Presencia de snapshots como indicativo de copias de seguridad.
+- Verificación de CPU Ready y memoria "balloon" en las VMs.
+- Comprobación básica de cumplimiento de actualizaciones en los hosts.
+- Alerta por datastores con más del 90% de uso.
+- Detección de IPv6 habilitado.
+- Cálculo de la relación vCPU/pCPU y políticas Round Robin en iSCSI.
+- Consistencia del nombre DNS configurado en cada host.
 
 El informe generado con `template_a.html` muestra nuevas secciones: un **Health Score** con métricas globales, un resumen por categorías (rendimiento, almacenamiento, seguridad y disponibilidad), indicadores de componentes clave y varias tablas con los 10 elementos más relevantes (CPU Ready, uso de RAM, capacidad de datastores, espacio libre de discos por VM, IOPS y tráfico de red).
+Además se incluyen indicadores extra como estado de actualizaciones, presencia de ballooning o discrepancias de DNS entre otros.
 
 
 El script mostrará por pantalla un resumen de la información recopilada para cada host y para cada máquina virtual encontrada.


### PR DESCRIPTION
## Summary
- add new VM/host metrics (ballooning, cpu cores, num cpu)
- extend health report builder with extra indicator calculations
- surface CPU Ready, ballooning, updates, storage, IPv6, vCPU/pCPU, round robin and DNS status in report
- record IPv6 configuration in security check
- document the additional checks in README

## Testing
- `python -m py_compile vmware_healthcheck.py`
- `flake8 vmware_healthcheck.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844a5a83424832c9d01119cfcd488ae