### PR TITLE
Fix template selection and RAM rankings

### DIFF
--- a/template_a.html
+++ b/template_a.html
@@ -295,20 +295,20 @@
           </table>
         </div>
       </div>
-      <!-- Card 2: TOP 10 Prioridad RAM (GB) -->
+      <!-- Card 2: TOP 10 RAM Promedio (%) -->
       <div class="card">
-        <div class="card-header"><i class="fa-solid fa-memory"></i> TOP 10 Prioridad RAM</div>
+        <div class="card-header"><i class="fa-solid fa-memory"></i> TOP 10 RAM Promedio</div>
         <div class="card-content">
           <table>
             <thead>
               <tr>
                 <th>VM</th>
-                <th>RAM (GB)</th>
+                <th>RAM (%)</th>
               </tr>
             </thead>
             <tbody>
               {% for vm in top_ram %}
-              <tr><td>{{ vm.name }}</td><td>{{ vm.metrics.mem_usage_gb }}</td></tr>
+              <tr><td>{{ vm.name }}</td><td>{{ (vm.metrics.mem_usage_pct * 100) | round(2) }}</td></tr>
               {% endfor %}
             </tbody>
           </table>

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -744,8 +744,16 @@ class VMwareHealthCheck:
         # Top lists
         running_vms = [v for v in vm_data if v['metrics'].get('power_state') == 'poweredOn']
 
-        top_cpu_ready = sorted(running_vms, key=lambda x: x['metrics'].get('cpu_ready_ms', 0), reverse=True)[:10]
-        top_ram = sorted(running_vms, key=lambda x: x['metrics'].get('mem_usage_gb', 0), reverse=True)[:10]
+        top_cpu_ready = sorted(
+            running_vms,
+            key=lambda x: x['metrics'].get('cpu_ready_ms', 0),
+            reverse=True
+        )[:10]
+        top_ram = sorted(
+            running_vms,
+            key=lambda x: x['metrics'].get('mem_usage_pct', 0),
+            reverse=True
+        )[:10]
         datastores_list = [ds for h in hosts_data for ds in h.get('performance', {}).get('datastores', [])]
         datastores_sorted = sorted(datastores_list, key=lambda x: x.get('capacity_gb', 0), reverse=True)[:10]
 
@@ -803,6 +811,10 @@ class VMwareHealthCheck:
         """
         logger.info("Generating HTML report: %s", output_file)
         chart = self._create_chart(hosts_data)
+
+        if os.path.isabs(template_file):
+            template_dir = os.path.dirname(template_file)
+            template_file = os.path.basename(template_file)
 
         if template_dir is None:
             template_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- sort top RAM list by average percentage instead of absolute memory
- allow absolute path for `--template-file`
- update advanced HTML template to show RAM percentage

## Testing
- `python -m py_compile vmware_healthcheck.py`

------
https://chatgpt.com/codex/tasks/task_b_6844a798ca78832c84c5c0948709f255