### PR TITLE
Add extended-html flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,19 @@ Adicionalmente, se incluye `template_a.html`, una plantilla avanzada con un form
 
 También se ha añadido `template_a_detailed.html`, una versión ampliada que incorpora una sección **Análisis Detallado** con cuatro bloques de texto (Rendimiento, Almacenamiento, Seguridad y Disponibilidad). Dichos textos se generan con IA si se indica la opción `--detailed-report`.
 
+De forma simplificada puede utilizarse `--extended-html`, que aplica automáticamente esta plantilla y habilita el informe detallado cuando se indica `--output`.
+
 Para obtener un informe extendido en HTML utilice el nombre de esta plantilla y especifique dónde guardar el texto generado:
 
 ```bash
 python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> \
   --output informe.html --template . --template-file template_a_detailed.html \
   --detailed-report report.txt
+```
+O bien utilizando la nueva opción:
+```bash
+python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> \
+  --output informe.html --template . --extended-html
 ```
 
 Recuerde exportar `OPENAI_API_KEY` y, en el caso de Azure OpenAI, `OPENAI_API_TYPE`, `OPENAI_API_BASE` y `OPENAI_API_VERSION` para que se puedan crear estos textos automáticamente.

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -1060,7 +1060,13 @@ def main():
     parser.add_argument('--detailed-report', metavar='FILE',
                         help='save an extended text report to FILE. If --output '
                              'is given, the text will be embedded in the HTML')
+    parser.add_argument('--extended-html', action='store_true',
+                        help='use template_a_detailed.html and enable detailed report generation')
     args = parser.parse_args()
+    if args.extended_html:
+        args.template_file = 'template_a_detailed.html'
+        if not args.detailed_report:
+            args.detailed_report = args.output
 
     checker = VMwareHealthCheck(args.host, args.user, args.password)
     try:


### PR DESCRIPTION
## Summary
- allow `--extended-html` CLI option to switch to the detailed template and generate the AI report by default
- document the new option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68454de11574832ca97a9e95d4fab38b