### PR TITLE
Add OpenAI config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ export OPENAI_API_BASE=https://<tu-recurso>.openai.azure.com/
 export OPENAI_API_VERSION=2023-05-15
 export OPENAI_API_KEY=<clave>
 ```
+En lugar de variables de entorno también puede crearse un archivo
+`openai_config.json` con estos mismos campos. El script lo cargará
+automáticamente si está presente (o si se indica la ruta en
+`OPENAI_CONFIG_FILE`). Un ejemplo de su contenido es:
+```json
+{
+  "api_key": "sk-xxxxxxxx",
+  "api_type": "openai",
+  "api_base": "",
+  "api_version": "",
+  "model": "gpt-3.5-turbo"
+}
+```
 Si también se indica `--output`, el texto se incluirá al final del HTML.
 Adicionalmente, se incluye `template_a.html`, una plantilla avanzada con un formato extendido y botones para exportar o imprimir el informe. Para utilizarla basta con indicar el directorio donde se encuentra mediante `--template` y pasar `--template-file template_a.html`.
 

--- a/openai_config.json
+++ b/openai_config.json
@@ -1,0 +1,7 @@
+{
+  "api_key": "sk-REEMPLAZA_CON_TU_CLAVE",
+  "api_type": "openai",
+  "api_base": "",
+  "api_version": "",
+  "model": "gpt-3.5-turbo"
+}

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import types
 from unittest.mock import patch
 
@@ -213,3 +214,27 @@ def test_generate_report_html(tmp_path):
     assert 'Seguridad' in html
     assert 'Disponibilidad' in html
     assert 'AI text' in html
+
+
+def test_configure_openai_from_file(tmp_path):
+    cfg = {
+        "api_key": "key",
+        "api_type": "azure",
+        "api_base": "base",
+        "api_version": "v",
+        "model": "m",
+    }
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps(cfg))
+
+    import openai_connector
+
+    openai_connector.configure_openai(config_file=str(cfg_file))
+    import openai as openai_mod
+
+    assert openai_mod.api_key == "key"
+    assert openai_mod.api_type == "azure"
+    assert openai_mod.api_base == "base"
+    assert openai_mod.api_version == "v"
+    assert openai_connector._DEFAULT_MODEL == "m"
+


### PR DESCRIPTION
## Summary
- add helper `load_openai_config` and integrate into `configure_openai`
- keep chosen model in `_DEFAULT_MODEL`
- read default model when fetching completions
- document config JSON usage in README
- provide sample `openai_config.json`
- test loading configuration from file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684544daa4b8832ca21d70104811403d