### PR TITLE
Add comprehensive template

### DIFF
--- a/template_full.html
+++ b/template_full.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>VMware Health Report - Estilo Minimalista</title>
+  <!-- Iconos -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <!-- Tipografía principal -->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet"/>
+  <!-- jsPDF (opcional, se recomienda window.print()) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <style>
+    /* RESET BÁSICO */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { width: 100%; height: 100%; font-family: 'Roboto', sans-serif; background: #fff; color: #000; line-height: 1.5; }
+    a { text-decoration: none; color: inherit; }
+    
+    /* CONTENEDOR PRINCIPAL */
+    .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+    
+    /* CABECERA */
+    header { display: flex; align-items: center; margin-bottom: 30px; }
+    .brand-logo img { height: 77px; }
+    
+    /* TÍTULOS */
+    h1, h2, h3 { font-weight: 700; margin-bottom: 10px; }
+    h1 { font-size: 1.75rem; margin-bottom: 15px; }
+    h2 { font-size: 1.3rem; margin-top: 30px; margin-bottom: 15px; }
+    h3 { font-size: 1.1rem; }
+    
+    /* SECCIÓN SCORE */
+    .score-section { display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; margin-bottom: 40px; gap: 20px; }
+    .score-wrapper { display: flex; flex-direction: column; align-items: center; flex: 1; min-width: 280px; }
+    .score-text { font-size: 5rem; font-weight: bold; margin-top: 10px; line-height: 1; }
+    .health-status { margin-top: 10px; padding: 5px 10px; border-radius: 5px; font-size: 1rem; font-weight: bold; display: inline-block; }
+    .health-status.optimal  { background: #4CAF50; color: #fff; }
+    .health-status.warning  { background: #FFC107; color: #fff; }
+    .health-status.critical { background: #FF5722; color: #fff; }
+    
+    /* MÉTRICAS E INFRAESTRUCTURA */
+    .metrics { display: flex; flex-direction: column; gap: 8px; margin-top: 20px; font-size: 0.95rem; }
+    .metrics .metric { display: flex; align-items: center; gap: 8px; }
+    .infra-summary { display: flex; flex-wrap: wrap; gap: 15px; margin-top: 15px; }
+    .infra-summary div { background: #f9f9f9; padding: 5px 10px; border-radius: 4px; display: flex; align-items: center; gap: 5px; font-size: 0.9rem; }
+    
+    /* ENLACES RÁPIDOS */
+    .quick-links { margin-top: 15px; display: flex; flex-wrap: wrap; gap: 10px; }
+    .quick-links a { background: #000; color: #fff; padding: 8px 12px; border-radius: 4px; font-size: 0.85rem; font-weight: 700; transition: background 0.3s ease; }
+    .quick-links a:hover { background: #333; }
+    .cover-section { text-align: center; margin-bottom: 40px; }
+    .cover-section p { margin: 5px 0; }
+
+    /* ÍNDICE */
+    .toc { margin-bottom: 30px; }
+    .toc ul { list-style: none; padding-left: 0; }
+    .toc li { margin: 4px 0; }
+    .toc a { text-decoration: underline; color: #0077cc; }
+    
+    /* SECCIÓN CATEGORÍAS */
+    .categories-section { margin-bottom: 40px; }
+    .categories-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 20px; }
+    .category-card { border: 1px solid #ddd; border-radius: 6px; padding: 15px; text-align: left; transition: box-shadow 0.3s ease; }
+    .category-card:hover { box-shadow: 0 4px 10px rgba(0,0,0,0.05); }
+    .category-card h4 { font-size: 1rem; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+    .category-status { font-size: 0.9rem; font-weight: bold; padding: 3px 6px; border-radius: 4px; margin-left: auto; }
+    .ok .category-status       { background: #4CAF50; color: #fff; }
+    .warning .category-status  { background: #FFC107; color: #fff; }
+    .critical .category-status { background: #FF5722; color: #fff; }
+    .category-progress { margin-top: 10px; height: 6px; width: 100%; background: #eee; border-radius: 3px; overflow: hidden; }
+    .category-progress span { display: block; height: 100%; transition: width 1s; }
+    .ok .category-progress span       { background: #4CAF50; }
+    .warning .category-progress span  { background: #FFC107; }
+    .critical .category-progress span { background: #FF5722; }
+    .category-score { font-size: 0.85rem; margin-top: 5px; font-weight: bold; }
+    
+    /* SECCIÓN GRÁFICOS: CPU, RAM Y DATASTORES */
+    .graphs-container { display: flex; flex-wrap: wrap; gap: 20px; margin-bottom: 40px; }
+    .graph-section { flex: 1; min-width: 280px; border: 1px solid #ddd; border-radius: 6px; padding: 15px; }
+    .server-row, .datastore-row {
+      display: flex; align-items: center; margin-bottom: 10px;
+    }
+    .server-label, .datastore-label {
+      width: 110px; font-weight: 700; font-size: 0.9rem; text-align: right; margin-right: 10px;
+    }
+    .server-bar-container, .datastore-bar-container {
+      flex: 1; background: #f1f1f1; border-radius: 4px; overflow: hidden; position: relative;
+    }
+    .server-bar, .datastore-bar {
+      height: 18px; line-height: 18px; text-align: right; padding-right: 5px;
+      color: #fff; font-size: 0.8rem; width: 0; transition: width 1.5s ease;
+    }
+    .cpu-bar { background: #4CAF50; }
+    .ram-bar { background: #ff7043; }
+    .datastore-bar { background: #0077cc; } /* Color para datastore */
+    
+    /* SECCIÓN ESTADO DE COMPONENTES CLAVE */
+    .indicator-section { margin-bottom: 40px; }
+    .indicator-section h2 { margin-bottom: 15px; }
+    .indicator-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 15px; margin-bottom: 20px;
+    }
+    .indicator-card {
+      border: 1px solid #ddd; border-radius: 6px; padding: 15px;
+      text-align: center; transition: box-shadow 0.3s ease; cursor: default;
+    }
+    .indicator-card:hover { box-shadow: 0 4px 10px rgba(0,0,0,0.05); }
+    .indicator-card i { font-size: 1.5rem; margin-bottom: 5px; color: #666; }
+    .indicator-card p { font-size: 0.9rem; font-weight: bold; margin: 8px 0; }
+    .status-ok       { color: #4CAF50; }
+    .status-warning  { color: #FFC107; }
+    .status-critical { color: #FF5722; }
+    
+    /* SECCIÓN TOP 10 LISTADOS */
+    .top-list { margin-bottom: 40px; }
+    .table-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+    .card {
+      border: 1px solid #ddd; border-radius: 6px;
+      padding: 15px; transition: box-shadow 0.3s ease;
+    }
+    .card:hover { box-shadow: 0 4px 10px rgba(0,0,0,0.05); }
+    .card-header {
+      font-size: 1rem; margin-bottom: 10px;
+      font-weight: 700; display: flex; align-items: center; gap: 6px;
+    }
+    .card-content table {
+      width: 100%; border-collapse: collapse;
+    }
+    .card-content th, .card-content td {
+      padding: 4px; font-size: 0.85rem;
+      border-bottom: 1px solid #f1f1f1; text-align: center;
+    }
+    .card-content th { background: #f9f9f9; font-weight: 700; }
+    .card-content td:last-child { font-weight: bold; }
+    /* SECCIÓN DETALLE IA */
+    .details-section { margin-bottom: 40px; }
+    .details-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; }
+    .detail-card { border: 1px solid #ddd; border-radius: 6px; padding: 15px; }
+    .detail-card h3 { font-size: 1rem; margin-bottom: 10px; }
+    .detail-card p { font-size: 0.9rem; line-height: 1.4; }
+
+    
+    /* FOOTER */
+    footer {
+      border-top: 1px solid #eee; padding: 20px 0;
+      text-align: center; font-size: 0.85rem; color: #777;
+    }
+    .export-btn {
+      margin-top: 10px; display: inline-block;
+      background: #000; color: #fff;
+      padding: 8px 15px; border-radius: 4px;
+      font-size: 0.8rem; text-transform: uppercase;
+      font-weight: 700; transition: background 0.3s ease;
+    }
+    .export-btn:hover { background: #333; }
+    
+    /* RESPONSIVIDAD MÓVIL */
+    @media (max-width: 768px) {
+      h1 { font-size: 1.4rem; }
+      h2 { font-size: 1.15rem; }
+      .score-section { flex-direction: column; }
+      .server-label, .datastore-label { width: 100px; }
+      .server-row, .datastore-row { flex-wrap: wrap; }
+      .table-grid, .indicator-grid { grid-template-columns: 1fr; }
+    }
+    
+    /* ESTILOS DE IMPRESIÓN: Forzar formato de escritorio */
+    @media print {
+      html, body { margin: 0; padding: 0; }
+      .container {
+        max-width: 1200px !important;
+        margin: 0 auto !important;
+        padding: 20px !important;
+      }
+      /* Forzamos grids a columnas fijas */
+      .indicator-grid { grid-template-columns: repeat(4, 1fr) !important; }
+      .table-grid { grid-template-columns: repeat(3, 1fr) !important; }
+      /* Ocultamos botones interactivos */
+      .quick-links, .export-btn { display: none !important; }
+      /* Eliminamos transformaciones */
+      html, body { transform: none !important; }
+      body { font-size: 12pt !important; }
+      header, footer, section { page-break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+<!-- CABECERA CON LOGO DE SERVIIT -->
+<header class="container">
+  <div class="brand-logo">
+    <img src="https://serviit.com/wp-content/uploads/2024/12/Logo_negro_fondo_blanco-200x77.png" alt="Logo Serviit">
+  </div>
+</header>
+
+<!-- PORTADA -->
+<section id="portada" class="container cover-section">
+  <h1>{{ report_title }}</h1>
+  <p><strong>Fecha:</strong> {{ report_date }}</p>
+  <p><strong>Autor:</strong> {{ author }}</p>
+  <p><strong>Alcance:</strong> {{ report_scope }}</p>
+</section>
+
+<!-- ÍNDICE CLICABLE -->
+<nav class="container toc">
+  <h2>Índice</h2>
+  <ul>
+    <li><a href="#resumen-ejecutivo">Resumen Ejecutivo</a></li>
+    <li><a href="#introduccion">Introducción</a></li>
+    <li><a href="#entorno">Resumen General del Entorno</a></li>
+    <li><a href="#categorias">Análisis por Categorías</a></li>
+    <li><a href="#indicadores">Estado de Componentes</a></li>
+    <li><a href="#top10">Top 10 Listados</a></li>
+    <li><a href="#recomendaciones">Recomendaciones</a></li>
+    <li><a href="#conclusiones">Conclusiones</a></li>
+    <li><a href="#glosario">Glosario</a></li>
+    <li><a href="#anexos">Anexos</a></li>
+  </ul>
+</nav>
+
+<!-- RESUMEN EJECUTIVO -->
+<section id="resumen-ejecutivo" class="container score-section">
+  <div class="score-wrapper">
+    <div style="font-size: 1.1rem; font-weight: 700; margin-bottom: 10px;">Health Score</div>
+    <div class="score-text">{{ health_score }}</div>
+    <span class="health-status {{ health_state }}">{{ health_message }}</span>
+  </div>
+  <div class="score-wrapper" style="align-items:flex-start;">
+    <div class="metrics">
+      <div class="metric"><i class="fa-solid fa-flag"></i> Estado Global: {{ global_state }}</div>
+      <div class="metric"><i class="fa-solid fa-triangle-exclamation"></i> Riesgos Clave: {{ key_risks }}</div>
+    </div>
+  </div>
+</section>
+
+<!-- INTRODUCCIÓN -->
+<section id="introduccion" class="container details-section">
+  <h2><i class="fa-solid fa-circle-info"></i> Introducción</h2>
+  <p><strong>Objetivo:</strong> {{ objective }}</p>
+  <p><strong>Alcance:</strong> {{ scope_text }}</p>
+  <p><strong>Metodología:</strong> {{ methodology }}</p>
+  <p>{{ environment_summary_text }}</p>
+</section>
+
+<!-- RESUMEN GENERAL DEL ENTORNO -->
+<section id="entorno" class="container score-section">
+  <div class="score-wrapper" style="align-items:flex-start;">
+    <div class="metrics">
+      <div class="metric"><i class="fa-solid fa-clock"></i> Tiempo Activo: {{ uptime }}</div>
+      <div class="metric"><i class="fa-solid fa-bell"></i> Alertas: {{ alerts }}</div>
+      <div class="metric"><i class="fa-solid fa-check"></i> SLA: {{ sla }}</div>
+    </div>
+    <div class="infra-summary">
+      <div><i class="fa-solid fa-server"></i> Hosts: <strong>{{ hosts|length }}</strong></div>
+      <div><i class="fa-solid fa-desktop"></i> VMs: <strong>{{ vms|length }}</strong></div>
+      <div><i class="fa-solid fa-database"></i> Datastores: <strong>{{ datastores_count }}</strong></div>
+      <div><i class="fa-solid fa-network-wired"></i> Redes: <strong>{{ networks_count }}</strong></div>
+    </div>
+    <div class="quick-links">
+      <a href="#" id="pdfBtn"><i class="fa-solid fa-file-pdf"></i> PDF</a>
+      <a href="#" id="printBtn"><i class="fa-solid fa-print"></i> Imprimir</a>
+    </div>
+  </div>
+</section>
+
+<!-- ANÁLISIS POR CATEGORÍAS -->
+<section id="categorias" class="container categories-section">
+  <h2><i class="fa-solid fa-chart-pie"></i> Análisis por Categorías</h2>
+  <div class="categories-grid">
+    {% for cat in categories %}
+    <div class="category-card {{ cat.status }}">
+      <h4><i class="{{ cat.icon }}"></i> {{ cat.name }} <span class="category-status">{{ cat.status|capitalize }}</span></h4>
+      <div class="category-progress"><span style="width: {{ cat.score }}%;"></span></div>
+      <div class="category-score">{{ cat.score }}%</div>
+    </div>
+    {% endfor %}
+  </div>
+  <div class="details-grid">
+    <div class="detail-card">
+      <h3><i class="fa-solid fa-gauge-high"></i> Rendimiento</h3>
+      <p>{{ performance_text }}</p>
+    </div>
+    <div class="detail-card">
+      <h3><i class="fa-solid fa-database"></i> Almacenamiento</h3>
+      <p>{{ storage_text }}</p>
+    </div>
+    <div class="detail-card">
+      <h3><i class="fa-solid fa-shield-halved"></i> Seguridad</h3>
+      <p>{{ security_text }}</p>
+    </div>
+    <div class="detail-card">
+      <h3><i class="fa-solid fa-plug-circle-bolt"></i> Disponibilidad</h3>
+      <p>{{ availability_text }}</p>
+    </div>
+  </div>
+</section>
+
+<!-- ESTADO DE COMPONENTES CLAVE -->
+<section id="indicadores" class="container indicator-section">
+  <h2><i class="fa-solid fa-clipboard-check"></i> Estado de Componentes Clave</h2>
+  <div class="indicator-grid">
+    {% for ind in indicators %}
+    <div class="indicator-card">
+      <i class="{{ ind.icon }}"></i>
+      <p>{{ ind.label|safe }}</p>
+      <span class="status-{{ ind.status }}">{{ ind.text }}</span>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+<!-- TOP 10 LISTADOS -->
+<section id="top10" class="container top-list">
+  <h2><i class="fa-solid fa-list-ol"></i> Top 10 Listados</h2>
+  <div class="table-grid">
+    <!-- Card 1: TOP 10 CPU Ready Time (ms) -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-microchip"></i> TOP 10 CPU Ready Time</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>VM</th>
+              <th>CPU Ready (ms)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for vm in top_cpu_ready %}
+            <tr><td>{{ vm.name }}</td><td>{{ vm.metrics.cpu_ready_ms }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <!-- Card 2: TOP 10 RAM Promedio (%) -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-memory"></i> TOP 10 RAM Promedio</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>VM</th>
+              <th>RAM (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for vm in top_ram %}
+            <tr><td>{{ vm.name }}</td><td>{{ (vm.metrics.mem_usage_pct * 100) | round(2) }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <!-- Card 3: DATASTORE (GB) -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-database"></i> DATASTORE (GB)</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>Datastore</th>
+              <th>Capacidad (GB)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for ds in datastores %}
+            <tr><td>{{ ds.name }}</td><td>{{ ds.capacity_gb }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <!-- Card 4: TOP 10 DISC FREE (%) -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-hdd"></i> TOP 10 DISC FREE (%)</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>VM</th>
+              <th>Disc Free (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for vm in top_disk_free %}
+            <tr><td>{{ vm.name }}</td><td>{{ vm.free_pct }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <!-- Card 5: TOP 10 IOPS VM -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-server"></i> TOP 10 IOPS VM</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>VM</th>
+              <th>IOPS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for vm in top_iops %}
+            <tr><td>{{ vm.name }}</td><td>{{ vm.metrics.iops }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <!-- Card 6: TOP 10 USO Red Prom (MBps) -->
+    <div class="card">
+      <div class="card-header"><i class="fa-solid fa-network-wired"></i> TOP 10 USO Red Prom (MBps)</div>
+      <div class="card-content">
+        <table>
+          <thead>
+            <tr>
+              <th>Switch</th>
+              <th>Red Prom (MBps)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for sw in top_network %}
+            <tr><td>{{ sw.name }}</td><td>{{ sw.metrics.net_throughput_kbps }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- RECOMENDACIONES Y PLAN DE ACCIÓN -->
+<section id="recomendaciones" class="container details-section">
+  <h2><i class="fa-solid fa-lightbulb"></i> Recomendaciones y Plan de Acción</h2>
+  <p>{{ recommendations }}</p>
+</section>
+
+<!-- CONCLUSIONES -->
+<section id="conclusiones" class="container details-section">
+  <h2><i class="fa-solid fa-flag-checkered"></i> Conclusiones</h2>
+  <p>{{ conclusions }}</p>
+</section>
+
+<!-- GLOSARIO -->
+<section id="glosario" class="container details-section">
+  <h2><i class="fa-solid fa-book"></i> Glosario</h2>
+  <p>{{ glossary }}</p>
+</section>
+
+<!-- ANEXOS -->
+<section id="anexos" class="container details-section">
+  <h2><i class="fa-solid fa-paperclip"></i> Anexos</h2>
+  <p>{{ annexes }}</p>
+</section>
+  <footer class="container">
+    <p>Informe generado el {{ report_date }}.</p>
+    <a href="#" class="export-btn" id="pdfBtn"><i class="fa-solid fa-file-export"></i> Exportar Reporte</a>
+  </footer>
+  
+  <!-- SCRIPT PARA PDF E IMPRESIÓN -->
+  <script>
+    // Función para generar PDF con jsPDF (puede tener limitaciones en el renderizado exacto)
+    document.getElementById("pdfBtn").addEventListener("click", function(e) {
+      e.preventDefault();
+      const { jsPDF } = window.jspdf;
+      const doc = new jsPDF();
+      doc.html(document.body, {
+        callback: function (doc) { doc.save('VMware_Health_Report.pdf'); },
+        x: 10, y: 10
+      });
+    });
+    // Botón de impresión nativo
+    const printBtn = document.getElementById("printBtn");
+    if (printBtn) {
+      printBtn.addEventListener("click", function(e) {
+        e.preventDefault();
+        window.print();
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `template_full.html` derived from the detailed template
- restructure sections with placeholders for portada, executive summary,
  introduction, environment summary, category analysis, indicators, top 10 tables
  and final recommendations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845853f82f8832c8e86747da48610b6