### PR TITLE
Add template_full support with new AI sections

### DIFF
--- a/report_sections/conclusions.py
+++ b/report_sections/conclusions.py
@@ -1,0 +1,22 @@
+"""Sección de conclusiones del informe detallado."""
+
+from openai_connector import fetch_completion
+
+INTRO = (
+    "Esta sección resume las conclusiones principales. "
+    "A continuación se añadirá el análisis generado por IA."
+)
+
+PROMPT_TEMPLATE = (
+    "Eres un experto en VMware. Debes redactar las conclusiones del informe "
+    "usando los siguientes datos:\n{data}"
+)
+
+def generate(data, model=None):
+    """Genera el texto detallado para la sección de conclusiones."""
+    prompt = PROMPT_TEMPLATE.format(data=data)
+    messages = [
+        {"role": "system", "content": "Eres un experto en VMware. Debes redactar un informe profesional."},
+        {"role": "user", "content": prompt},
+    ]
+    return fetch_completion(messages, model)

--- a/report_sections/executive_summary.py
+++ b/report_sections/executive_summary.py
@@ -1,0 +1,22 @@
+"""Sección de resumen ejecutivo del informe detallado."""
+
+from openai_connector import fetch_completion
+
+INTRO = (
+    "Esta sección ofrece un resumen ejecutivo del informe. "
+    "A continuación se añadirá el análisis generado por IA."
+)
+
+PROMPT_TEMPLATE = (
+    "Eres un experto en VMware. Debes redactar un resumen ejecutivo "
+    "utilizando los siguientes datos:\n{data}"
+)
+
+def generate(data, model=None):
+    """Genera el texto detallado para el resumen ejecutivo."""
+    prompt = PROMPT_TEMPLATE.format(data=data)
+    messages = [
+        {"role": "system", "content": "Eres un experto en VMware. Debes redactar un informe profesional."},
+        {"role": "user", "content": prompt},
+    ]
+    return fetch_completion(messages, model)

--- a/report_sections/glossary.py
+++ b/report_sections/glossary.py
@@ -1,0 +1,22 @@
+"""Sección de glosario del informe detallado."""
+
+from openai_connector import fetch_completion
+
+INTRO = (
+    "Esta sección define los términos clave utilizados en el informe. "
+    "A continuación se añadirá el análisis generado por IA."
+)
+
+PROMPT_TEMPLATE = (
+    "Eres un experto en VMware. Debes crear un glosario breve utilizando "
+    "los siguientes datos:\n{data}"
+)
+
+def generate(data, model=None):
+    """Genera el texto detallado para el glosario."""
+    prompt = PROMPT_TEMPLATE.format(data=data)
+    messages = [
+        {"role": "system", "content": "Eres un experto en VMware. Debes redactar un informe profesional."},
+        {"role": "user", "content": prompt},
+    ]
+    return fetch_completion(messages, model)

--- a/report_sections/recommendations.py
+++ b/report_sections/recommendations.py
@@ -1,0 +1,22 @@
+"""Sección de recomendaciones del informe detallado."""
+
+from openai_connector import fetch_completion
+
+INTRO = (
+    "Esta sección presenta recomendaciones y acciones a seguir. "
+    "A continuación se añadirá el análisis generado por IA."
+)
+
+PROMPT_TEMPLATE = (
+    "Eres un experto en VMware. Debes redactar recomendaciones y un plan de "
+    "acción usando los siguientes datos:\n{data}"
+)
+
+def generate(data, model=None):
+    """Genera el texto detallado para la sección de recomendaciones."""
+    prompt = PROMPT_TEMPLATE.format(data=data)
+    messages = [
+        {"role": "system", "content": "Eres un experto en VMware. Debes redactar un informe profesional."},
+        {"role": "user", "content": prompt},
+    ]
+    return fetch_completion(messages, model)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -69,6 +69,7 @@ class DummyEnvironment:
 
 jinja2_mod.Environment = DummyEnvironment
 jinja2_mod.FileSystemLoader = DummyLoader
+jinja2_mod.TemplateNotFound = type('TemplateNotFound', (Exception,), {})
 sys.modules.setdefault("jinja2", jinja2_mod)
 
 from vmware_healthcheck import VMwareHealthCheck
@@ -213,6 +214,22 @@ def test_generate_report_html(tmp_path):
     assert 'Rendimiento' in html
     assert 'Seguridad' in html
     assert 'Disponibilidad' in html
+    assert 'AI text' in html
+
+
+def test_generate_report_full_html(tmp_path):
+    output = tmp_path / 'full.html'
+    checker = _checker()
+    with patch.object(checker, '_create_chart', return_value='c'), \
+         patch.object(checker, 'licensing_check', return_value=['key']), \
+         patch.object(checker, 'backup_config_check', return_value=0), \
+         patch.object(checker, 'folder_inconsistencies', return_value=[]), \
+         patch('openai_connector.fetch_completion', return_value='AI text'):
+        checker.generate_report(HOSTS, VMS, str(output), template_file='template_full.html')
+
+    html = output.read_text()
+    assert 'Recomendaciones y Plan de Acción' in html
+    assert 'Glosario' in html
     assert 'AI text' in html
 
 


### PR DESCRIPTION
## Summary
- add executive summary, recommendations, conclusions and glossary modules
- generate AI content for template_full.html
- test template_full generation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684592251db0832ca933df5c43c45f95