### PR TITLE
Add full-html option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password
   --output informe.html --template . --extended-html
 ```
 
+Asimismo se incluye `template_full.html`, una versión con 12 secciones estructuradas.
+Puede emplearse fácilmente con:
+```bash
+python vmware_healthcheck.py --host <vcenter o esxi> --user <usuario> --password <contraseña> \
+  --output informe.html --template . --full-html
+```
+
 El archivo `template_a_detailed.html` incluye ahora un pequeño índice clicable
 para navegar por las secciones principales del informe. Una vez generado el
 HTML puede convertirse en PDF con vínculos internos utilizando el script

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -1219,9 +1219,15 @@ def main():
                              'is given, the text will be embedded in the HTML')
     parser.add_argument('--extended-html', action='store_true',
                         help='use template_a_detailed.html and enable detailed report generation')
+    parser.add_argument('--full-html', action='store_true',
+                        help='use template_full.html and enable detailed report generation (produces the structured 12-section report)')
     args = parser.parse_args()
     if args.extended_html:
         args.template_file = 'template_a_detailed.html'
+        if not args.detailed_report:
+            args.detailed_report = args.output
+    if args.full_html:
+        args.template_file = 'template_full.html'
         if not args.detailed_report:
             args.detailed_report = args.output
 


### PR DESCRIPTION
## Summary
- add `--full-html` CLI flag to activate the full template and detailed report
- mention the feature in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684593c2c700832ca4df086b62d38ee8