### PR TITLE
Add api-type option for VMware healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ ejemplo sería:
 }
 ```
 Este repositorio incluye `openai_config_azure.json` como referencia.
+Si se desea escoger explícitamente el tipo de servicio al ejecutar
+`vmware_healthcheck.py`, puede indicarse mediante la opción
+`--api-type`, que acepta los valores `openai` o `azure`. También es
+posible especificar un archivo de configuración distinto con
+`--openai-config <archivo>`.
 Para verificar la configuración de OpenAI se incluye `check_openai_connection.py`.
 Ejecútelo para confirmar que la clave y el endpoint son correctos:
 ```bash

--- a/openai_report.py
+++ b/openai_report.py
@@ -3,7 +3,11 @@
 from openai_connector import configure_openai, fetch_completion
 
 
-def generate_detailed_report(summary: str, api_key: str, model: str) -> str:
+def generate_detailed_report(summary: str, api_key: str, model: str,
+                             api_type: str | None = None,
+                             api_base: str | None = None,
+                             api_version: str | None = None,
+                             config_file: str | None = None) -> str:
     """Generates a professional VMware report using OpenAI or Azure OpenAI.
 
     Parameters
@@ -13,14 +17,30 @@ def generate_detailed_report(summary: str, api_key: str, model: str) -> str:
     api_key : str
         OpenAI API key.
     model : str
-        Model name to use (e.g. 'gpt-3.5-turbo' or 'gpt-4').
+        Model name or deployment to use.
+    api_type : str, optional
+        ``"openai"`` or ``"azure"``. If ``None`` the value is taken from the
+        environment or configuration file.
+    api_base : str, optional
+        Azure OpenAI endpoint URL. Ignored for the ``openai`` type.
+    api_version : str, optional
+        Azure OpenAI API version.
+    config_file : str, optional
+        Path to a JSON file with the configuration parameters.
 
     Returns
     -------
     str
         Full report text returned by the language model.
     """
-    configure_openai(api_key=api_key, model=model)
+    configure_openai(
+        api_key=api_key,
+        api_type=api_type,
+        api_base=api_base,
+        api_version=api_version,
+        model=model,
+        config_file=config_file,
+    )
 
     messages = [
         {

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -1223,6 +1223,10 @@ def main():
                         help='use template_full.html and enable detailed report generation (produces the structured 12-section report)')
     parser.add_argument('--full-html-es', action='store_true',
                         help='use template_full_es.html (versi\xc3\xb3n en espa\xc3\xb1ol) and enable detailed report generation')
+    parser.add_argument('--api-type', choices=['openai', 'azure'],
+                        help='select OpenAI backend (openai or azure)')
+    parser.add_argument('--openai-config',
+                        help='path to JSON file with OpenAI/Azure settings')
     args = parser.parse_args()
     if args.extended_html:
         args.template_file = 'template_a_detailed.html'
@@ -1342,7 +1346,13 @@ def main():
             else:
                 try:
                     summary_text = checker.build_text_summary(hosts_data, summary)
-                    detailed_text = generate_detailed_report(summary_text, api_key, model)
+                    detailed_text = generate_detailed_report(
+                        summary_text,
+                        api_key,
+                        model,
+                        api_type=args.api_type,
+                        config_file=args.openai_config,
+                    )
                     if not args.output or args.detailed_report != args.output:
                         with open(args.detailed_report, 'w', encoding='utf-8') as f:
                             f.write(detailed_text)


### PR DESCRIPTION
## Summary
- support selecting OpenAI vs Azure OpenAI via `--api-type`
- allow supplying a custom config file with `--openai-config`
- expose new parameters in `generate_detailed_report`
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845ab839ae8832c94c1a76ef7e55080