### PR TITLE
Improve Azure OpenAI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ reconocidas por la librería `openai`.
 python check_azure_openai_connection.py
 ```
 Si no se indica un archivo de configuración concreto, el script buscará
-automáticamente `openai_config_azure.json` en el directorio actual.
+automáticamente `openai_config_azure.json` en el directorio actual. Del mismo
+modo, `vmware_healthcheck.py` cargará este archivo si se ejecuta con
+`--api-type azure` y no se especifica otra ruta.
 Si también se indica `--output`, el texto se incluirá al final del HTML.
 Adicionalmente, se incluye `template_a.html`, una plantilla avanzada con un formato extendido y botones para exportar o imprimir el informe. Para utilizarla basta con indicar el directorio donde se encuentra mediante `--template` y pasar `--template-file template_a.html`.
 

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -7,6 +7,37 @@ import openai
 _DEFAULT_MODEL = None
 
 
+def apply_azure_env_vars(force=False, verbose=False):
+    """Map Azure-specific variables to the names expected by ``openai``."""
+    found = False
+    key = os.getenv("AZURE_OPENAI_KEY")
+    if key:
+        os.environ.setdefault("OPENAI_API_KEY", key)
+        found = True
+        if verbose:
+            print("Usando AZURE_OPENAI_KEY")
+    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    if endpoint:
+        os.environ.setdefault("OPENAI_API_BASE", endpoint)
+        found = True
+        if verbose:
+            print(f"Endpoint: {endpoint}")
+    version = os.getenv("AZURE_OPENAI_VERSION")
+    if version:
+        os.environ.setdefault("OPENAI_API_VERSION", version)
+        found = True
+        if verbose:
+            print(f"Versión: {version}")
+    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+    if deployment:
+        os.environ.setdefault("OPENAI_MODEL", deployment)
+        found = True
+        if verbose:
+            print(f"Deployment: {deployment}")
+    if force or found:
+        os.environ["OPENAI_API_TYPE"] = "azure"
+
+
 def load_openai_config(path=None, verbose=False):
     """Carga la configuración de OpenAI desde un archivo JSON."""
     config_path = path or os.getenv("OPENAI_CONFIG_FILE", "openai_config.json")
@@ -29,6 +60,10 @@ def load_openai_config(path=None, verbose=False):
 def configure_openai(api_key=None, api_type=None, api_base=None, api_version=None,
                      model=None, config_file=None, verbose=False):
     """Configura la librería ``openai`` para usar OpenAI o Azure OpenAI."""
+    if api_type == "azure" or os.getenv("OPENAI_API_TYPE") == "azure":
+        apply_azure_env_vars(force=True, verbose=verbose)
+    else:
+        apply_azure_env_vars(verbose=verbose)
     cfg = load_openai_config(config_file, verbose=verbose)
 
     key = api_key or os.getenv("OPENAI_API_KEY") or cfg.get("api_key")

--- a/vmware_healthcheck.py
+++ b/vmware_healthcheck.py
@@ -10,6 +10,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from openai_report import generate_detailed_report
+from openai_connector import apply_azure_env_vars
 
 logging.basicConfig(
     level=logging.INFO,
@@ -1240,6 +1241,13 @@ def main():
         args.template_file = 'template_full_es.html'
         if not args.detailed_report:
             args.detailed_report = args.output
+
+    if args.api_type == 'azure':
+        apply_azure_env_vars(force=True)
+        if not args.openai_config and os.path.isfile('openai_config_azure.json'):
+            args.openai_config = 'openai_config_azure.json'
+        if args.openai_config:
+            os.environ.setdefault('OPENAI_CONFIG_FILE', args.openai_config)
 
     checker = VMwareHealthCheck(args.host, args.user, args.password)
     try:


### PR DESCRIPTION
## Summary
- map `AZURE_OPENAI_*` variables automatically
- fall back to `openai_config_azure.json` when using `--api-type azure`
- document new behaviour in README
- automatically set `OPENAI_CONFIG_FILE` when using Azure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6845b4fa0eb8832ca693493a2cb6a40a